### PR TITLE
feat: card switch on clicking buttons

### DIFF
--- a/components/ContinueButton.js
+++ b/components/ContinueButton.js
@@ -1,9 +1,11 @@
 import styled from "styled-components";
 
-export default function ContinueButton() {
+export default function ContinueButton({ handleClick }) {
   return (
     <ButtonWrapper>
-      <StyledContinueButton>Continue</StyledContinueButton>
+      <StyledContinueButton onClick={handleClick}>
+        Continue
+      </StyledContinueButton>
     </ButtonWrapper>
   );
 }
@@ -15,11 +17,12 @@ const StyledContinueButton = styled.button`
   border: none;
   padding: 1rem 1.5rem;
   border-radius: 10px;
+  font-family: Roboto !important;
+  font-weight: 300;
 `;
 
 const ButtonWrapper = styled.div`
   display: flex;
   justify-content: center;
   margin-top: 3rem;
-  font-family: Roboto;
 `;

--- a/pages/learn.js
+++ b/pages/learn.js
@@ -3,31 +3,71 @@ import Navbar from "../components/Navbar";
 import Card from "../components/Card";
 import ToggleButton from "../components/ToggleButton";
 import CheckButton from "../components/CheckButton";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import styled from "styled-components";
 import FailureButton from "../components/FailureButton";
-import Button from "../components/Button";
+import ContinueButton from "../components/ContinueButton";
 
 export default function Learn() {
   const [showTranslation, setShowTranslation] = useState(false);
-  const [newCard, setNewCard] = useState(false);
+  const [words, setWords] = useState(frenchVocabulary);
+  const [index, setIndex] = useState(0);
+  const [card, setCard] = useState(null);
+  const [displayButtons, setDisplayButtons] = useState(false);
+  const [actionButtonsClicked, setActionButtonsClicked] = useState(false);
+
+  // Related to card changes
+  useEffect(() => {
+    setCard(() => words[index]);
+    setActionButtonsClicked(false);
+  }, [index, words]);
+
+  // Related to words changes (new set of words)
+  useEffect(() => {
+    setIndex(0);
+  }, [words]);
+
+  // Related to change index (go to next card)
+  useEffect(() => {
+    setShowTranslation(false);
+    setDisplayButtons(false);
+  }, [index]);
+
+  function checkHandleClick() {
+    setActionButtonsClicked(true);
+
+    setIndex((currentIndex) => {
+      if (currentIndex < words.length - 1) {
+        return currentIndex + 1;
+      }
+
+      return currentIndex;
+    });
+  }
 
   return (
     <Layout>
       <StyledMain>
-        <Card
-          content="Bonjour"
-          translation="Guten Tag"
-          showTranslation={showTranslation}
-        />
-        <ButtonWrapper>
-          <FailureButton />
-          <ToggleButton
-            handleClick={() => setShowTranslation(!showTranslation)}
+        {card && (
+          <Card
+            content={card.content}
+            translation={card.translation}
+            showTranslation={showTranslation}
           />
-          <CheckButton />
+        )}
+        <ButtonWrapper>
+          {displayButtons && <FailureButton handleClick={checkHandleClick} />}
+          <ToggleButton
+            handleClick={() => {
+              setShowTranslation(!showTranslation);
+              setDisplayButtons(true);
+            }}
+          />
+          {displayButtons && <CheckButton handleClick={checkHandleClick} />}
         </ButtonWrapper>
-        <Button />
+        {index === frenchVocabulary.length - 1 && actionButtonsClicked && (
+          <ContinueButton handleClick={() => setWords(frenchVocabularyTwo)} />
+        )}
       </StyledMain>
       <Navbar />
     </Layout>
@@ -49,25 +89,34 @@ const frenchVocabulary = [
   {
     content: "meilleur/e",
     translation: "besser",
+    id: 1,
   },
   {
     content: "s'énerver",
     translation: "sich aufregen",
+    id: 2,
   },
   {
     content: "la farine",
     translation: "Mehl",
+    id: 3,
   },
+];
+
+const frenchVocabularyTwo = [
   {
     content: "avoir raison",
     translation: "recht haben",
+    id: 4,
   },
   {
     content: "la plate-bande",
     translation: "Beet, Rabatte",
+    id: 5,
   },
   {
     content: "la jonquille",
     translation: "Osterglocke, Narzisse",
+    id: 6,
   },
 ];


### PR DESCRIPTION
- created CheckButton-component
- created FailureButton-component
- added event handler on Check- and FailureButton
- created ContinueButton-component
- implemented feature: when finishing a set of cards, ContinueButton appears; a new set of cards can be started

(user stories: check answer and switch cards)